### PR TITLE
Prevent failure git commit when no git user or email was set

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -2,4 +2,10 @@
 
 git init
 git add .
+username="inmanta-project-template"
+email=""
+export GIT_COMMITTER_NAME="${username}"
+export GIT_COMMITTER_EMAIL="${email}"
+export GIT_AUTHOR_NAME="${username}"
+export GIT_AUTHOR_EMAIL="${email}"
 git commit -m "initial commit: cookiecutter template"


### PR DESCRIPTION
Ensure that git commit doesn't fail when no username or email has been configured in git.

Closes #10