### PR TITLE
improved support for pip config

### DIFF
--- a/{{cookiecutter.project_name}}/project.yml
+++ b/{{cookiecutter.project_name}}/project.yml
@@ -13,3 +13,4 @@ repo:
       url: {{cookiecutter.repo_url}}
 install_mode: {{cookiecutter.install_mode}}
 requires:
+pip: { use_config_file: False }


### PR DESCRIPTION
improved support for pip config

add pip: { use_config_file: False} to template 

closes [#5976](https://github.com/inmanta/inmanta-core/issues/5976)
closes [#6052](https://github.com/inmanta/inmanta-core/issues/6052)
